### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/malin/rengwuxianrxjava/factory/DataFactory.java
+++ b/app/src/main/java/com/malin/rengwuxianrxjava/factory/DataFactory.java
@@ -38,6 +38,9 @@ import java.util.ArrayList;
  */
 public class DataFactory {
 
+    private DataFactory() {
+    }
+
     /**
      * 获取学生集合
      *

--- a/app/src/main/java/com/malin/rengwuxianrxjava/factory/ImageNameFactory.java
+++ b/app/src/main/java/com/malin/rengwuxianrxjava/factory/ImageNameFactory.java
@@ -40,6 +40,9 @@ public class ImageNameFactory {
     private static final String FOLDER_NAME_THREE = "rengwuxian";
     private static final String FOLDER_NAME_FOUR = "thisisdaimajiagirlfriends";
 
+    private ImageNameFactory() {
+    }
+
     /**
      * 获取asset目录下的文件夹的名称集合
      *

--- a/app/src/main/java/com/malin/rengwuxianrxjava/utils/ClickUtils.java
+++ b/app/src/main/java/com/malin/rengwuxianrxjava/utils/ClickUtils.java
@@ -40,6 +40,10 @@ public class ClickUtils {
     private static long lastClickTime = 0L;
     private static final boolean isDebug = true;
     private static final String BLANK_LOG = "\t";
+
+    private ClickUtils() {
+    }
+
     /**
      * 用于处理频繁点击问题, 如果两次点击小于500毫秒则不予以响应
      *

--- a/app/src/main/java/com/malin/rengwuxianrxjava/utils/ImageUtils.java
+++ b/app/src/main/java/com/malin/rengwuxianrxjava/utils/ImageUtils.java
@@ -51,6 +51,9 @@ public class ImageUtils {
 
     private static final String TAG = "PaoWuXian_RxJava";
 
+    private ImageUtils() {
+    }
+
     /**
      * 从assets文件夹中获取制定路径的图片的Bitmap
      *

--- a/app/src/main/java/com/malin/rengwuxianrxjava/utils/RecycleBitmap.java
+++ b/app/src/main/java/com/malin/rengwuxianrxjava/utils/RecycleBitmap.java
@@ -39,6 +39,9 @@ import android.widget.ImageView;
  */
 
 public class RecycleBitmap {
+    private RecycleBitmap() {
+    }
+
     /**
      * 回收ImageView占用的图像内存;
      *

--- a/app/src/main/java/com/malin/rengwuxianrxjava/utils/RxUtils.java
+++ b/app/src/main/java/com/malin/rengwuxianrxjava/utils/RxUtils.java
@@ -30,6 +30,9 @@ import rx.subscriptions.CompositeSubscription;
 
 public class RxUtils {
 
+    private RxUtils() {
+    }
+
     public static void unsubscribeIfNotNull(Subscription subscription) {
         if (subscription != null) {
             subscription.unsubscribe();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
